### PR TITLE
Support also non UML diagram types of PlantUML

### DIFF
--- a/src/services/plantUMLService.ts
+++ b/src/services/plantUMLService.ts
@@ -9,7 +9,9 @@ export class PlantUMLService {
     }
 
     public isValidPlantUMLCode(code: string): boolean {
-        return code.includes('@startuml') && code.includes('@enduml');
+        // Match any @startXYZ ... @endXYZ pattern
+        const regex = /@start([a-z0-9_]+)[\s\S]*?@end\1/i;
+        return regex.test(code);
     }
 
     public generateSVGUrl(code: string): string {


### PR DESCRIPTION
Refactor isValidPlantUMLCode to use regex for validation @start..... & @end.... to also support non UML diagrams of PlantUML. E.g. @startjson ... @endjson, and so on. See: https://plantuml.com/en/